### PR TITLE
Recorded the storage decisions from wayfinder ticket #7

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,7 +15,7 @@ The coarse, user-facing enum derived from the job state by a single pure mapping
 ### Files
 
 **Job file**:
-A stored media file attached to a job — an input or an output — recorded as a row in its own table (`job_files`): storage key, size, probe metadata (duration, resolution, codec…), content hash, and per-file lifecycle stamps (expiry, deletion). Job files can expire and be deleted from storage while the job record lives on. Supersedes the POC meaning of "job file" (the JSON job definition loaded by the console app), which does not exist in the backend.
+A stored media file attached to a job — an input or an output — recorded as a row in its own table (`job_files`): storage key, size, probe metadata (duration, resolution, codec…), and per-file lifecycle stamps (expiry, deletion). Job files can expire and be deleted from storage while the job record lives on. Supersedes the POC meaning of "job file" (the JSON job definition loaded by the console app), which does not exist in the backend.
 
 ### Parameters
 

--- a/docs/adr/0004-cloudflare-r2-object-storage.md
+++ b/docs/adr/0004-cloudflare-r2-object-storage.md
@@ -1,0 +1,13 @@
+# Cloudflare R2 is the object storage
+
+All job files — uploaded inputs and produced outputs — live in Cloudflare R2, accessed through the standard S3 API (AWSSDK.S3, region `auto`) behind our own storage interface. R2 wins on the pipeline's defining trait: every stored byte is transferred out at least once (worker pull + user download, plus retries and re-downloads), and R2 egress is genuinely free and uncapped, so downloads, previews and retries never enter a cost or design conversation. Storage is $0.015/GB-month with no minimum; at the realistic launch profile (short-to-medium videos, ≤ ~300 MB typical, ~500 jobs/month, 30-day retention) that is single-digit dollars per month, with ~$60/month as the heavy-usage ceiling (500 jobs/month at 8 GB per job).
+
+Buckets are per-environment (`seedvr-prod`, `seedvr-dev`), created with default placement (no location hint — changing placement later means a new bucket plus a copy, acceptable while data is small). Object keys are direction-rooted — `in/{jobId}/{fileId}`, `out/{jobId}/{fileId}` — because R2 lifecycle rules match literal prefixes only, and the top-level split keeps per-direction retention rules expressible; per-job grouping is the database's job (`job_files` rows hold full keys), never the bucket's.
+
+R2 caveats carried into the design: presigned uploads are PUT only (no POST policies), presigned URLs cap at 7 days, multipart parts must be equal-sized, and the abort-incomplete-multipart lifecycle rule ships on day one.
+
+## Considered Options
+
+- AWS S3. Rejected — ~7x the cost at our egress profile (~$443 vs ~$60/month at the heavy ceiling); the egress line dominates and widens with growth.
+- Wasabi. Rejected — 90-day minimum storage duration bills 30-day-deleted objects for 90 days, and its egress fair-use line (egress ≤ stored volume) sits exactly at our profile, with suspension as the enforcement.
+- Backblaze B2 (the named fallback). Cheaper on paper (~$28 vs ~$60/month at the ceiling; both round toward zero at realistic launch sizes), and safe at our 1:1 egress ratio — its free-egress cap of 3x stored volume only starts costing beyond ~3.8x, and overage is billed, never suspended. R2 chosen anyway: egress stays free under any future download-heavy behavior (previews, shorter retention shrinking B2's allowance), and the credential and presigning flows were verified on R2. Both speak S3, so the storage interface keeps the switching cost near zero.

--- a/docs/adr/0005-workers-hold-no-storage-credentials.md
+++ b/docs/adr/0005-workers-hold-no-storage-credentials.md
@@ -1,0 +1,13 @@
+# Workers hold no storage credentials
+
+GPU workers run on Vast.ai marketplace machines — rented hardware whose host operator has root on the Docker host and can read anything a container holds, a risk Vast's own security guidance acknowledges and its trust tiers only reduce. Therefore no S3 credential of any kind travels to a worker. Inputs reach the worker as presigned GET URLs embedded in the workflow JSON; outputs are uploaded by our own service bundled into the worker image, using a per-job presigned PUT URL minted by the backend for the predetermined output key (`out/{jobId}/{fileId}`). A stolen presigned URL grants one operation on one object for a bounded time — there is nothing to rotate and no bucket-wide blast radius.
+
+This rules out the ai-dock wrapper's built-in S3 upload mode (`input.s3`), which requires a real access key and secret in every request: R2's static tokens have no write-only level (a leak reads, overwrites and deletes every object in scope until rotated, silently), and R2's temporary credentials need a session token the stock wrapper cannot carry. The bundled uploader also puts the output key layout under our control, which the wrapper (no prefix setting) never offered.
+
+Consequence: outputs beyond the single-PUT limit (~5 GiB) need backend-orchestrated multipart presigning; at the typical ≤ ~300 MB output this is a rare path, not the norm.
+
+## Considered Options
+
+- Static bucket-scoped read-write token in each request (Vast's own serverless template pattern). Rejected — a silent leak from any rented host exposes all customer files until a rotation nobody is prompted to run; write-only static tokens do not exist on R2.
+- Per-job temporary credentials (bucket/prefix-scoped, short TTL, optionally write-only via local signing). Viable and researched, but requires threading a session token through the upload path; presigned PUTs achieve stricter containment with less machinery.
+- Per-job presigned PUT/GET URLs, zero credentials on the host (chosen) — the industry-standard answer for untrusted workers.

--- a/docs/v2-features.md
+++ b/docs/v2-features.md
@@ -1,0 +1,7 @@
+# V2 features
+
+Useful features consciously deferred out of v1. Each entry names the feature, why it earns a place, and what v1 does instead. Entries are added as planning decisions defer them; an entry graduates by becoming an ordinary ticket when its time comes.
+
+## Multipart / resumable browser uploads
+
+Uploads beyond the 2 GB v1 cap, and resume-after-disconnect for large uploads, need backend-orchestrated multipart presigning (create-multipart, sign each part, complete — R2 requires equal-size parts). V1 uses a single presigned PUT with the 2 GB input cap; a dropped connection restarts the upload. The API contract carries an upload-mechanics discriminator so multipart can be added without breaking v1 clients.


### PR DESCRIPTION
Artifacts from resolving [Storage choice and upload/delivery flow #7](https://github.com/Astral100/SeedVr.Backend/issues/7):

- Added ADR 0004: Cloudflare R2 as object storage, direction-rooted keys, B2 as the named fallback
- Added ADR 0005: workers hold no storage credentials, presigned URLs in both directions
- Added the V2 features document with the multipart/resumable upload deferral
- Removed the content hash from the glossary's Job file entry

Fast-forward content: one commit on top of master, no conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)